### PR TITLE
Silence extraneous output from jlist

### DIFF
--- a/lib/capistrano/tasks/pm2.rake
+++ b/lib/capistrano/tasks/pm2.rake
@@ -69,7 +69,7 @@ namespace :pm2 do
 
   def app_status
     within current_path do
-      ps = JSON.parse(capture :pm2, :jlist)
+      ps = JSON.parse(capture :pm2, :jlist, :'-s')
 
       # find the process with our app name
       ps.each do |child|


### PR DESCRIPTION
Calling pm2 jlist when the pm2 service is not running triggers pm2
to start the daemon process and emit banner and status text. This is not
parseable json and breaks capistrano-pm2's app_status method when ran on an
instance where the daemon is not started.

This patch adds the -s silent running argument introduced into pm2 version
2.4.0 - https://github.com/Unitech/pm2/issues/281