### PR TITLE
Use "pm2_env_variables" on all pm2 execution

### DIFF
--- a/lib/capistrano/tasks/pm2.rake
+++ b/lib/capistrano/tasks/pm2.rake
@@ -69,23 +69,27 @@ namespace :pm2 do
 
   def app_status
     within current_path do
-      ps = JSON.parse(capture :pm2, :jlist, :'-s')
+      with fetch(:pm2_env_variables) do
+        ps = JSON.parse(capture :pm2, :jlist, :'-s')
 
-      # find the process with our app name
-      ps.each do |child|
-        if child['name'] == app_name
-          # status: online, errored, stopped
-          return child['pm2_env']['status']
+        # find the process with our app name
+        ps.each do |child|
+          if child['name'] == app_name
+            # status: online, errored, stopped
+            return child['pm2_env']['status']
+          end
         end
-      end
 
-      return nil
+        return nil
+      end
     end
   end
 
   def restart_app
     within current_path do
-      execute :pm2, :restart, app_name
+      with fetch(:pm2_env_variables) do
+        execute :pm2, :restart, app_name
+      end
     end
   end
 


### PR DESCRIPTION
This changes has resolved the path of pm2 with environment variables.

My usecase:

```rb
set pm2_env_variables, { PATH: '/home/ubuntu/.nodebrew/current/bin:$PATH' }
```

Thank you. @tomhanoldt