### PR TITLE
PM2 cwd path should always be the current path

### DIFF
--- a/lib/capistrano/tasks/pm2.rake
+++ b/lib/capistrano/tasks/pm2.rake
@@ -30,7 +30,7 @@ namespace :pm2 do
 
   desc 'Start pm2 application'
   task :start do
-    run_task :pm2, :start, fetch(:pm2_app_command), "--name #{app_name} #{fetch(:pm2_start_params)}"
+    run_task :pm2, :start, fetch(:pm2_app_command), "--cwd #{current_path} --name #{app_name} #{fetch(:pm2_start_params)}"
   end
 
   desc 'Stop pm2 application'


### PR DESCRIPTION
Currently PM2 server starts in the release folder, which when you restart, the server will restart in the release folder

The working folder should always be current folder.

Also related to https://github.com/Unitech/pm2/issues/1663