### PR TITLE
Fit to current pm2

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,29 +27,17 @@ Require in `Capfile` to use the default task:
 require 'capistrano/pm2'
 ```
 
-The task will run before `deploy:restart` as part of Capistrano's default deploy,
-or can be run in isolation with `cap production pm2:restart`. You can also invoke it in your `deploy.rb`:
-```ruby
-namespace :deploy do
-  desc 'Restart application'
-  task :restart do
-    # invoke 'npm:install'
-    invoke 'pm2:restart'
-  end
-
-  after :publishing, :restart
-end
-```
-
-
 Available Tasks
 ```ruby
 cap pm2:delete                     # Delete pm2 application
 cap pm2:list                       # Show pm2 application info
 cap pm2:logs                       # Watch pm2 logs
-cap pm2:restart                    # Restart app gracefully
+cap pm2:reload                     # Reload app gracefully
+cap pm2:restart                    # Restart app
 cap pm2:setup                      # Install pm2 via npm on the remote host
 cap pm2:start                      # Start pm2 application
+cap pm2:start_or_reload            # Start or gracefully reload pm2 application
+cap pm2:start_or_restart           # Start or restart pm2 application
 cap pm2:status                     # List all pm2 applications
 cap pm2:stop                       # Stop pm2 application
 cap pm2:save                       # Save pm2 state so it can be loaded after restart
@@ -62,7 +50,8 @@ set :pm2_app_name, fetch(:application)            # name for pm2 app
 set :pm2_target_path, -> { release_path }         # where to run pm2 commands
 set :pm2_roles, :all                              # server roles where pm2 runs on
 set :pm2_env_variables, {}                        # default: env vars for pm2
-set :pm2_start_params, ''                         # pm2 start params see http://pm2.keymetrics.io/docs/usage/quick-start/#cheat-sheet
+set :pm2_config_path, ''                          # pm2 ecosystem file path
+set :pm2_options, -> { "--cwd #{fetch(:current_path)} --name #{fetch(:application)}" } # options for pm2 CLI
 ```
 
 ## Contributing

--- a/lib/capistrano/tasks/pm2.rake
+++ b/lib/capistrano/tasks/pm2.rake
@@ -125,7 +125,11 @@ namespace :load do
     set :pm2_app_name, nil
     set :pm2_start_params, ''
     set :pm2_config_path, ''
-    set :pm2_options, -> { "--cwd #{current_path} }
+    set :pm2_options, -> {
+      opts = "--cwd #{current_path}"
+      opts += "--name #{app_name}" if fetch(:pm2_config_path).empty?
+      opts
+    }
     set :pm2_roles, :all
     set :pm2_env_variables, {}
   end

--- a/lib/capistrano/tasks/pm2.rake
+++ b/lib/capistrano/tasks/pm2.rake
@@ -90,10 +90,7 @@ namespace :load do
     set :pm2_app_name, nil
     set :pm2_config_path, ''
     set :pm2_options, -> {
-      opts = "--cwd #{fetch(:current_path)}"
-      opts += "--name #{fetch(:pm2_app_name) || fetch(:application)}" \
-        if fetch(:pm2_config_path).empty?
-      opts
+      fetch(:pm2_config_path).empty? ? "--cwd #{current_path} --name #{app_name}" : ''
     }
     set :pm2_roles, :all
     set :pm2_env_variables, {}

--- a/lib/capistrano/tasks/pm2.rake
+++ b/lib/capistrano/tasks/pm2.rake
@@ -108,6 +108,14 @@ namespace :pm2 do
     end
   end
 
+  def script_or_config
+    if fetch(:pm2_config_path).empty?
+      fetch(:pm2_app_command)
+    else
+      fetch(:pm2_config_path)
+    end
+  end
+
   def run_task(*args)
     on roles fetch(:pm2_roles) do
       within fetch(:pm2_target_path, release_path) do

--- a/lib/capistrano/tasks/pm2.rake
+++ b/lib/capistrano/tasks/pm2.rake
@@ -33,6 +33,21 @@ namespace :pm2 do
     run_task :pm2, :start, fetch(:pm2_app_command), "--cwd #{current_path} --name #{app_name} #{fetch(:pm2_start_params)}"
   end
 
+  desc 'Reload pm2 application'
+  task :reload do
+    run_task :pm2, :reload, app_name, fetch(:pm2_options)
+  end
+
+  desc 'Start or restart pm2 application'
+  task :start_or_restart do
+    run_task :pm2, :startOrRestart, fetch(:pm2_config_path), fetch(:pm2_options)
+  end
+
+  desc 'Start or gracefully reload pm2 application'
+  task :start_or_reload do
+    run_task :pm2, :startOrReload, fetch(:pm2_config_path), fetch(:pm2_options)
+  end
+
   desc 'Stop pm2 application'
   task :stop do
     run_task :pm2, :stop, app_name
@@ -109,6 +124,8 @@ namespace :load do
     set :pm2_app_command, 'main.js'
     set :pm2_app_name, nil
     set :pm2_start_params, ''
+    set :pm2_config_path, ''
+    set :pm2_options, -> { "--cwd #{current_path} }
     set :pm2_roles, :all
     set :pm2_env_variables, {}
   end

--- a/lib/capistrano/tasks/pm2.rake
+++ b/lib/capistrano/tasks/pm2.rake
@@ -90,8 +90,9 @@ namespace :load do
     set :pm2_app_name, nil
     set :pm2_config_path, ''
     set :pm2_options, -> {
-      opts = "--cwd #{current_path}"
-      opts += "--name #{app_name}" if fetch(:pm2_config_path).empty?
+      opts = "--cwd #{fetch(:current_path)}"
+      opts += "--name #{fetch(:pm2_app_name) || fetch(:application)}" \
+        if fetch(:pm2_config_path).empty?
       opts
     }
     set :pm2_roles, :all


### PR DESCRIPTION
Thanks for a useful capistrano plugin. This changes is not compatible for now. However, since pm2 now recommends the use of ecosystem file and our way of usage also changes accordingly, I think that capistrano-pm2 needs to follow it as well.

### Behavior

task | current behavior | new behavior
-- | -- | --
restart | start or restart gracefully | only exec restart
reload | nothing | only exec reload
start_or_restart | nothing | only exec startOrRestart
start_or_reload | nothing | only exec startOrReload

### Add attributes

- pm2_options: options for pm2 CLI
- pm2_config: ecosystem file for pm2